### PR TITLE
Resolves #3: Window use single thread for dataloading for inference_images.py

### DIFF
--- a/inference_images.py
+++ b/inference_images.py
@@ -98,7 +98,7 @@ dataset = ZipDataset([
     HomographicAlignment() if args.preprocess_alignment else A.PairApply(nn.Identity()),
     A.PairApply(T.ToTensor())
 ]))
-dataloader = DataLoader(dataset, batch_size=1, num_workers=8, pin_memory=True)
+dataloader = DataLoader(dataset, batch_size=1, num_workers=0, pin_memory=True)
 
 
 # Create output directory


### PR DESCRIPTION
based on suggestion from https://github.com/PeterL1n/BackgroundMattingV2/issues/22#issuecomment-752873981